### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-pulumi-cloud/main.go
+++ b/cmd/baton-pulumi-cloud/main.go
@@ -49,7 +49,7 @@ func getConnector(ctx context.Context, pc *cfg.PulumiCloud) (types.ConnectorServ
 		return nil, err
 	}
 
-	c, err := client.NewClient(pc.AccessToken)
+	c, err := client.NewClient(pc.AccessToken, pc.BaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,6 +8,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
+// DefaultBaseURL is the default Pulumi Cloud API URL.
+const DefaultBaseURL = "https://api.pulumi.com"
+
 // Client represents a Pulumi API client.
 type Client struct {
 	baseHttpClient *uhttp.BaseHttpClient
@@ -16,8 +19,12 @@ type Client struct {
 }
 
 // NewClient creates a new Pulumi API client.
-func NewClient(token string) (*Client, error) {
-	baseURL, err := url.Parse("https://api.pulumi.com")
+// If baseURL is empty, DefaultBaseURL is used.
+func NewClient(token string, baseURL string) (*Client, error) {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -34,7 +41,7 @@ func NewClient(token string) (*Client, error) {
 
 	return &Client{
 		baseHttpClient: wrapper,
-		baseURL:        baseURL,
+		baseURL:        parsedURL,
 		token:          token,
 	}, nil
 }

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type PulumiCloud struct {
 	AccessToken string `mapstructure:"access-token"`
 	OrgName string `mapstructure:"org-name"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *PulumiCloud) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Pulumi Cloud API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	Config = field.NewConfiguration([]field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,18 +6,28 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
-var Config = field.NewConfiguration([]field.SchemaField{
-	field.StringField(
+var (
+	AccessTokenField = field.StringField(
 		"access-token",
 		field.WithRequired(true),
 		field.WithDescription("The access token for the Pulumi Cloud organization"),
-	),
-	field.StringField(
+	)
+	OrgNameField = field.StringField(
 		"org-name",
 		field.WithRequired(true),
 		field.WithDescription("The name of the Pulumi Cloud organization"),
-	),
-})
+	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Pulumi Cloud API URL (for testing)"),
+	)
+
+	Config = field.NewConfiguration([]field.SchemaField{
+		AccessTokenField,
+		OrgNameField,
+		BaseURLField,
+	})
+)
 
 func ValidateConfig(c *PulumiCloud) error {
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Pulumi Cloud API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	Config = field.NewConfiguration([]field.SchemaField{


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-pulumi-cloud/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-pulumi-cloud --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.