### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -34,9 +34,8 @@ func teamResource(team client.Team, parentResourceId *v2.ResourceId) (*v2.Resour
 		team.DisplayName,
 		teamResourceType,
 		team.Name,
-		[]batonResource.GroupTraitOption{
-			batonResource.WithGroupProfile(profile),
-		},
+		[]batonResource.GroupTraitOption{},
+		batonResource.WithResourceProfile(profile),
 		batonResource.WithParentResourceID(parentResourceId),
 	)
 }

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -32,8 +32,6 @@ func userResource(user *client.User, parentResourceId *v2.ResourceId) (*v2.Resou
 
 	userTraits := []batonResource.UserTraitOption{
 		batonResource.WithUserLogin(user.User.GithubLogin),
-		batonResource.WithUserProfile(profile),
-		batonResource.WithStatus(userStatus),
 		batonResource.WithAccountType(accountType),
 	}
 
@@ -47,6 +45,8 @@ func userResource(user *client.User, parentResourceId *v2.ResourceId) (*v2.Resou
 		userResourceType,
 		user.User.GithubLogin,
 		userTraits,
+		batonResource.WithResourceProfile(profile),
+		batonResource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		batonResource.WithParentResourceID(parentResourceId),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
